### PR TITLE
MovieReservation prijzen fix

### DIFF
--- a/CinemaSystemProjectB/CustomerReservation.Designer.cs
+++ b/CinemaSystemProjectB/CustomerReservation.Designer.cs
@@ -48,7 +48,7 @@
             this.TotalStudents = new System.Windows.Forms.Label();
             this.TotalSeniors = new System.Windows.Forms.Label();
             this.MoviePanel = new System.Windows.Forms.Panel();
-            this.ChooseOrChangeSeatsButton = new System.Windows.Forms.Button();
+            this.SelectedSeatsDisplay = new System.Windows.Forms.Label();
             this.TotalBestSeatPrice = new System.Windows.Forms.Label();
             this.TotalGoodSeatPrice = new System.Windows.Forms.Label();
             this.TotalNormalSeatPrice = new System.Windows.Forms.Label();
@@ -316,7 +316,7 @@
             // 
             // MoviePanel
             // 
-            this.MoviePanel.Controls.Add(this.ChooseOrChangeSeatsButton);
+            this.MoviePanel.Controls.Add(this.SelectedSeatsDisplay);
             this.MoviePanel.Controls.Add(this.TotalBestSeatPrice);
             this.MoviePanel.Controls.Add(this.TotalGoodSeatPrice);
             this.MoviePanel.Controls.Add(this.TotalNormalSeatPrice);
@@ -384,19 +384,16 @@
             this.MoviePanel.TabIndex = 304;
             this.MoviePanel.MouseEnter += new System.EventHandler(this.MoviePanel_MouseEnter);
             // 
-            // ChooseOrChangeSeatsButton
+            // SelectedSeatsDisplay
             // 
-            this.ChooseOrChangeSeatsButton.BackColor = System.Drawing.Color.DarkRed;
-            this.ChooseOrChangeSeatsButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ChooseOrChangeSeatsButton.Font = new System.Drawing.Font("Arial", 11F, System.Drawing.FontStyle.Bold);
-            this.ChooseOrChangeSeatsButton.ForeColor = System.Drawing.Color.Black;
-            this.ChooseOrChangeSeatsButton.Location = new System.Drawing.Point(98, 547);
-            this.ChooseOrChangeSeatsButton.Name = "ChooseOrChangeSeatsButton";
-            this.ChooseOrChangeSeatsButton.Size = new System.Drawing.Size(701, 28);
-            this.ChooseOrChangeSeatsButton.TabIndex = 375;
-            this.ChooseOrChangeSeatsButton.Text = "Klik hier om uw zitplaatsen te bekijken of te wijzigen\r\n";
-            this.ChooseOrChangeSeatsButton.UseVisualStyleBackColor = false;
-            this.ChooseOrChangeSeatsButton.Click += new System.EventHandler(this.ChooseOrChangeSeatsButton_Click);
+            this.SelectedSeatsDisplay.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.SelectedSeatsDisplay.ForeColor = System.Drawing.Color.Yellow;
+            this.SelectedSeatsDisplay.Location = new System.Drawing.Point(110, 539);
+            this.SelectedSeatsDisplay.Name = "SelectedSeatsDisplay";
+            this.SelectedSeatsDisplay.Size = new System.Drawing.Size(668, 79);
+            this.SelectedSeatsDisplay.TabIndex = 375;
+            this.SelectedSeatsDisplay.Text = "Geselecteerde stoelen";
+            this.SelectedSeatsDisplay.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // TotalBestSeatPrice
             // 
@@ -541,7 +538,7 @@
             this.label10.AutoSize = true;
             this.label10.Font = new System.Drawing.Font("Arial", 13F, System.Drawing.FontStyle.Bold);
             this.label10.ForeColor = System.Drawing.Color.Yellow;
-            this.label10.Location = new System.Drawing.Point(735, 605);
+            this.label10.Location = new System.Drawing.Point(735, 634);
             this.label10.Name = "label10";
             this.label10.Size = new System.Drawing.Size(49, 21);
             this.label10.TabIndex = 360;
@@ -551,7 +548,7 @@
             // label8
             // 
             this.label8.BackColor = System.Drawing.Color.Maroon;
-            this.label8.Location = new System.Drawing.Point(99, 626);
+            this.label8.Location = new System.Drawing.Point(99, 655);
             this.label8.Name = "label8";
             this.label8.Size = new System.Drawing.Size(700, 2);
             this.label8.TabIndex = 356;
@@ -562,7 +559,7 @@
             this.Snacks.BackColor = System.Drawing.Color.Transparent;
             this.Snacks.Font = new System.Drawing.Font("Arial", 13F, System.Drawing.FontStyle.Bold);
             this.Snacks.ForeColor = System.Drawing.Color.Yellow;
-            this.Snacks.Location = new System.Drawing.Point(115, 620);
+            this.Snacks.Location = new System.Drawing.Point(115, 649);
             this.Snacks.Name = "Snacks";
             this.Snacks.Size = new System.Drawing.Size(164, 42);
             this.Snacks.TabIndex = 358;
@@ -842,7 +839,7 @@
             this.FoodLabel.BackColor = System.Drawing.Color.Transparent;
             this.FoodLabel.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.FoodLabel.ForeColor = System.Drawing.Color.Yellow;
-            this.FoodLabel.Location = new System.Drawing.Point(115, 605);
+            this.FoodLabel.Location = new System.Drawing.Point(115, 634);
             this.FoodLabel.Name = "FoodLabel";
             this.FoodLabel.Size = new System.Drawing.Size(146, 38);
             this.FoodLabel.TabIndex = 357;
@@ -855,7 +852,7 @@
             this.SnackPrice.BackColor = System.Drawing.Color.Transparent;
             this.SnackPrice.Font = new System.Drawing.Font("Arial", 13F, System.Drawing.FontStyle.Bold);
             this.SnackPrice.ForeColor = System.Drawing.Color.Yellow;
-            this.SnackPrice.Location = new System.Drawing.Point(723, 621);
+            this.SnackPrice.Location = new System.Drawing.Point(723, 650);
             this.SnackPrice.Name = "SnackPrice";
             this.SnackPrice.Size = new System.Drawing.Size(55, 21);
             this.SnackPrice.TabIndex = 361;
@@ -963,6 +960,6 @@
         public System.Windows.Forms.Label TotalBestSeatPrice;
         public System.Windows.Forms.Label TotalGoodSeatPrice;
         public System.Windows.Forms.Label TotalNormalSeatPrice;
-        private System.Windows.Forms.Button ChooseOrChangeSeatsButton;
+        public System.Windows.Forms.Label SelectedSeatsDisplay;
     }
 }

--- a/CinemaSystemProjectB/CustomerReservation.cs
+++ b/CinemaSystemProjectB/CustomerReservation.cs
@@ -73,18 +73,6 @@ namespace CinemaSystemProjectB
 			}
 		}
 
-		public static bool clicked = false;
-		public static CustomerReservation CustomerMovie;
-
-		private void ChooseOrChangeSeatsButton_Click(object sender, EventArgs e)
-		{
-			CustomerMovie = this;
-			clicked = true;
-			SeatReservation screen_number = new SeatReservation((Filmtitle.Text + Filmtechnology.Text + date.Text + ScreenLabel.Text).ToString(), ScreenLabel.Text, this.ScreenLabel.Text == "Zaal 1" ? 12 : this.ScreenLabel.Text == "Zaal 2" ? 18 : 30);
-			screen_number.ShowDialog();
-			clicked = false;
-		}
-
 		private void MoviePanel_MouseEnter(object sender, EventArgs e)
 		{
 

--- a/CinemaSystemProjectB/MovieReservation.Designer.cs
+++ b/CinemaSystemProjectB/MovieReservation.Designer.cs
@@ -364,9 +364,9 @@
             this.ReservationPriceLabel.ForeColor = System.Drawing.Color.Yellow;
             this.ReservationPriceLabel.Location = new System.Drawing.Point(337, 693);
             this.ReservationPriceLabel.Name = "ReservationPriceLabel";
-            this.ReservationPriceLabel.Size = new System.Drawing.Size(320, 44);
+            this.ReservationPriceLabel.Size = new System.Drawing.Size(309, 44);
             this.ReservationPriceLabel.TabIndex = 72;
-            this.ReservationPriceLabel.Text = "Totale prijs van uw reservering: €\r\n\r\n";
+            this.ReservationPriceLabel.Text = "Totale prijs van uw reservering: \r\n\r\n";
             this.ReservationPriceLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // ReservationPrice
@@ -374,7 +374,7 @@
             this.ReservationPrice.AutoSize = true;
             this.ReservationPrice.Font = new System.Drawing.Font("Arial", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.ReservationPrice.ForeColor = System.Drawing.Color.Yellow;
-            this.ReservationPrice.Location = new System.Drawing.Point(651, 693);
+            this.ReservationPrice.Location = new System.Drawing.Point(633, 693);
             this.ReservationPrice.Name = "ReservationPrice";
             this.ReservationPrice.Size = new System.Drawing.Size(48, 22);
             this.ReservationPrice.TabIndex = 73;
@@ -404,7 +404,7 @@
             this.gradientLabel1.Controls.Add(this.Bioscoopnaam);
             this.gradientLabel1.EndColor = System.Drawing.Color.Maroon;
             this.gradientLabel1.Location = new System.Drawing.Point(-3, -2);
-            this.gradientLabel1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.gradientLabel1.Margin = new System.Windows.Forms.Padding(2);
             this.gradientLabel1.Name = "gradientLabel1";
             this.gradientLabel1.Size = new System.Drawing.Size(1113, 121);
             this.gradientLabel1.TabIndex = 56;

--- a/CinemaSystemProjectB/MovieReservation.cs
+++ b/CinemaSystemProjectB/MovieReservation.cs
@@ -551,8 +551,8 @@ namespace CinemaSystemProjectB
 					decimal totalPriceOfReservation = 0;
 					foreach (CustomerReservation movie in CustomerReservationPage.Controls)
 					{
-						movie.Snacks.Text = "";
-						movie.SnackPrice.Text = "";
+						movie.Snacks.Text = string.Empty;
+						movie.SnackPrice.Text = string.Empty;
 						decimal TotalPricesSnacks = 0;
 
 						movie.TotalPeople.Text = (SelectedMovies[n].comboBoxAdult.SelectedIndex + SelectedMovies[n].comboBoxKids.SelectedIndex).ToString();
@@ -560,52 +560,81 @@ namespace CinemaSystemProjectB
 
 						movie.TotalKids.Text = SelectedMovies[n].comboBoxKids.SelectedIndex.ToString();
 
-						int temp = SelectedMovies[n].comboBoxStudent.SelectedIndex;
-						int temp2 = SelectedMovies[n].comboBoxSenior.SelectedIndex;
+						int NumberOfStudents = SelectedMovies[n].comboBoxStudent.SelectedIndex;
+						int NumberOfSeniors = SelectedMovies[n].comboBoxSenior.SelectedIndex;
+
 						//Check wether the customer selected the comboboxes for student/senior. If not, the total will be zero.
 						if (SelectedMovies[n].comboBoxStudent.SelectedIndex.ToString() == "-1")
 						{
-							temp = 0;
+							NumberOfStudents = 0;
 						}
 						if (SelectedMovies[n].comboBoxSenior.SelectedIndex.ToString() == "-1")
 						{
-							temp2 = 0;
+							NumberOfSeniors = 0;
 						}
-						movie.TotalStudents.Text = temp.ToString();
-						movie.TotalSeniors.Text = temp2.ToString();
+						movie.TotalStudents.Text = NumberOfStudents.ToString();
+						movie.TotalSeniors.Text = NumberOfSeniors.ToString();
 
-						movie.PriceAdult.Text = "€" + (((SelectedMovies[n].comboBoxAdult.SelectedIndex - temp - temp2) * 10 < 10 ? "    " : (SelectedMovies[n].comboBoxAdult.SelectedIndex - temp - temp2) * 10 < 100 ? "  " : "")  + (SelectedMovies[n].comboBoxAdult.SelectedIndex - temp - temp2) * 10).ToString()+ ",00";
-						movie.PriceKids.Text = "€" + ((SelectedMovies[n].comboBoxKids.SelectedIndex) * 5 < 10 ? "    " : (SelectedMovies[n].comboBoxKids.SelectedIndex * 5) < 100 ? "  " : "") + (SelectedMovies[n].comboBoxKids.SelectedIndex * 5).ToString() + ",00";
-						movie.PriceStudent.Text = "€" + ((temp * 8) < 10 ? "    " : (temp * 8) < 100 ? "  " : "") + (temp * 8).ToString() + ",00";
-						movie.PriceSenior.Text = "€" + ((temp2 * 7) < 10 ? "    " : (temp2 * 7) < 100 ? "  " : "") + (temp2 * 7).ToString() + ",00";
+						//€ + amount of spaces + price + ,00
+						movie.PriceAdult.Text = "€" +
+							(((SelectedMovies[n].comboBoxAdult.SelectedIndex - NumberOfStudents - NumberOfSeniors) * 10 < 10 ?
+							"    " :
+							(SelectedMovies[n].comboBoxAdult.SelectedIndex - NumberOfStudents - NumberOfSeniors) * 10 < 100 ?
+							"  " : "") + (SelectedMovies[n].comboBoxAdult.SelectedIndex - NumberOfStudents - NumberOfSeniors) * 10).ToString() + ",00";
+
+						movie.PriceKids.Text = "€" +
+							((SelectedMovies[n].comboBoxKids.SelectedIndex) * 5 < 10 ?
+							"    " : (SelectedMovies[n].comboBoxKids.SelectedIndex * 5) < 100 ?
+							"  " : "") + (SelectedMovies[n].comboBoxKids.SelectedIndex * 5).ToString() + ",00";
+
+						movie.PriceStudent.Text = "€" +
+							((NumberOfStudents * 8) < 10 ? "    " : (NumberOfStudents * 8) < 100 ?
+							"  " : "") + (NumberOfStudents * 8).ToString() + ",00";
+
+						movie.PriceSenior.Text = "€" +
+							((NumberOfSeniors * 7) < 10 ? "    " : (NumberOfSeniors * 7) < 100 ?
+							"  " : "") + (NumberOfSeniors * 7).ToString() + ",00";
 
 						movie.NormalSeat.Text = SelectedMovies[n].TotalNormalSeats.Text;
 						movie.GoodSeat.Text = SelectedMovies[n].TotalGoodSeats.Text;
 						movie.BestSeat.Text = SelectedMovies[n].TotalBestSeats.Text;
-						
-						string temp3 = "";
-						string temp4 = "";
 
-						if((Convert.ToInt32(SelectedMovies[n].TotalGoodSeats.Text)) < 0)
+						string TotalGoodSeatsPrice = string.Empty;
+						string TotalBestSeatsPrice = string.Empty;
+
+						if ((Convert.ToInt32(SelectedMovies[n].TotalGoodSeats.Text)) < 0)
 						{
-							temp3 = "    0";
+							TotalGoodSeatsPrice = "    0";
 						}
 						else
 						{
-							temp3 = ((Convert.ToInt32(SelectedMovies[n].TotalGoodSeats.Text) * 1) < 10 ? "    " : (Convert.ToInt32(SelectedMovies[n].TotalGoodSeats.Text) * 1) < 100 ? "  " : "") + (Convert.ToInt32(SelectedMovies[n].TotalGoodSeats.Text) * 1).ToString();
+							TotalGoodSeatsPrice = ((Convert.ToInt32(SelectedMovies[n].TotalGoodSeats.Text) * 1) < 10 ? "    " : (Convert.ToInt32(SelectedMovies[n].TotalGoodSeats.Text) * 1) < 100 ? "  " : "") + (Convert.ToInt32(SelectedMovies[n].TotalGoodSeats.Text) * 1).ToString();
 						}
 						if ((Convert.ToInt32(SelectedMovies[n].TotalBestSeats.Text)) < 0)
 						{
-							temp4 = "    0";
+							TotalBestSeatsPrice = "    0";
 						}
 						else
 						{
-							temp4 = ((Convert.ToInt32(SelectedMovies[n].TotalBestSeats.Text) * 2) < 10 ? "    " : (Convert.ToInt32(SelectedMovies[n].TotalBestSeats.Text) * 2) < 100 ? "  " : "") + (Convert.ToInt32(SelectedMovies[n].TotalBestSeats.Text) * 2).ToString();
+							TotalBestSeatsPrice = ((Convert.ToInt32(SelectedMovies[n].TotalBestSeats.Text) * 2) < 10 ? "    " : (Convert.ToInt32(SelectedMovies[n].TotalBestSeats.Text) * 2) < 100 ? "  " : "") + (Convert.ToInt32(SelectedMovies[n].TotalBestSeats.Text) * 2).ToString();
 						}
 
+						string displaySeats = "Uw geselecteerde stoel(en): ";
+						List<string> ListOfSeats = SelectedMovies[n].CustomerChosenSeats.Keys.ToList();
+						for(int i = 0; i < ListOfSeats.Count; i++)
+						{
+							if(i + 1 == ListOfSeats.Count)
+							{
+								displaySeats += ListOfSeats[i];
+								break;
+							}
+							displaySeats += ListOfSeats[i] + ", ";
+						}
+
+						movie.SelectedSeatsDisplay.Text = displaySeats;
 						movie.TotalNormalSeatPrice.Text = "€    0,00";
-						movie.TotalGoodSeatPrice.Text = "€" + temp3 + ",00";
-						movie.TotalBestSeatPrice.Text = "€" + temp4 + ",00";
+						movie.TotalGoodSeatPrice.Text = "€" + TotalGoodSeatsPrice + ",00";
+						movie.TotalBestSeatPrice.Text = "€" + TotalBestSeatsPrice + ",00";
 
 						for (int c = 0; c < CustomerReservationPage.Controls.Count; c++)
 						{
@@ -623,7 +652,10 @@ namespace CinemaSystemProjectB
 									if (!(ReservedMovies[c].Snacks.Text.Contains(snacks[p].Key)))
 									{
 										ReservedMovies[c].Snacks.Text += Environment.NewLine + allComboboxes[p].SelectedIndex.ToString() + "x" + "	 " + snacks[p].Key;
-										ReservedMovies[c].SnackPrice.Text += Environment.NewLine + "€" + ((Decimal.Parse(snacks[p].Value) * allComboboxes[p].SelectedIndex) < 10 ? "    " : (Decimal.Parse(snacks[p].Value) * allComboboxes[p].SelectedIndex) < 100 ? "  " : "") + (Decimal.Parse(snacks[p].Value) * allComboboxes[p].SelectedIndex);
+										ReservedMovies[c].SnackPrice.Text += Environment.NewLine + "€" +
+																								((Decimal.Parse(snacks[p].Value) * allComboboxes[p].SelectedIndex) < 10 ?
+																								"    " : (Decimal.Parse(snacks[p].Value) * allComboboxes[p].SelectedIndex) < 100 ?
+																								"  " : "") + (Decimal.Parse(snacks[p].Value) * allComboboxes[p].SelectedIndex);
 										TotalPricesSnacks += (Decimal.Parse(snacks[p].Value) * allComboboxes[p].SelectedIndex);
 									}
 								}
@@ -652,14 +684,30 @@ namespace CinemaSystemProjectB
 							AddPriceSenior = SelectedMovies[n].comboBoxSenior.SelectedIndex;
 						}
 
-						movie.TotalPrice.Text = "€" + (Convert.ToDecimal((SelectedMovies[n].comboBoxAdult.SelectedIndex - temp - temp2) * 10) + Convert.ToDecimal((SelectedMovies[n].comboBoxKids.SelectedIndex) * 5) + Convert.ToDecimal(AddPriceStudent * 8) + Convert.ToDecimal(AddPriceSenior * 7) + Convert.ToDecimal(temp3) + Convert.ToDecimal(temp4) + TotalPricesSnacks).ToString();
-						totalPriceOfReservation += (Convert.ToDecimal((SelectedMovies[n].comboBoxAdult.SelectedIndex - temp - temp2) * 10) + Convert.ToDecimal((SelectedMovies[n].comboBoxKids.SelectedIndex) * 5) + Convert.ToDecimal(AddPriceStudent * 8) + Convert.ToDecimal(AddPriceSenior * 7) + Convert.ToDecimal(temp3) + Convert.ToDecimal(temp4) + TotalPricesSnacks );
+						decimal price = (
+							Convert.ToDecimal((SelectedMovies[n].comboBoxAdult.SelectedIndex - NumberOfStudents - NumberOfSeniors) * 10) +
+							Convert.ToDecimal((SelectedMovies[n].comboBoxKids.SelectedIndex) * 5) +
+							Convert.ToDecimal(AddPriceStudent * 8) + Convert.ToDecimal(AddPriceSenior * 7) +
+							Convert.ToDecimal(TotalGoodSeatsPrice) + Convert.ToDecimal(TotalBestSeatsPrice) + TotalPricesSnacks
+						);
+
+						string priceString = "€" + price.ToString();
+						if  (!priceString.EndsWith(",00"))
+							priceString += ",00";
+
+						movie.TotalPrice.Text = priceString;
+						totalPriceOfReservation += price;
 						n++;
 					}
 
 					ReservationPriceLabel.Visible = true;
 					ReservationPrice.Visible = true;
-					ReservationPrice.Text = totalPriceOfReservation.ToString();
+
+					string totalPriceString = "€" + totalPriceOfReservation.ToString();
+					if (!totalPriceString.EndsWith(",00"))
+						totalPriceString += ",00";
+					MessageBox.Show(totalPriceString);
+					ReservationPrice.Text = totalPriceString;
 				}
 			}
 		}
@@ -911,7 +959,6 @@ namespace CinemaSystemProjectB
 				Dictionary<string, int[][]> AllMovieSeats = JsonConvert.DeserializeObject<Dictionary<string, int[][]>>(File.ReadAllText(@"ReservedSeats.json"));
 
 				//saves all selected seats
-				//File.WriteAllText(@"ReservedSeats.json", new JObject() { { (SelectedMovies[i].MovieTitle + SelectedMovies[i].FilmTechnology + SelectedMovies[i].Date + SelectedMovies[i].Screen).ToString(), JArray.FromObject(SelectedMovies[i].newBlocks) } }.ToString());
 				if (!(AllMovieSeats.ContainsKey((SelectedMovies[i].MovieTitle + SelectedMovies[i].FilmTechnology + SelectedMovies[i].Date + SelectedMovies[i].Screen).ToString())))
 				{
 					AllMovieSeats.Add((SelectedMovies[i].MovieTitle + SelectedMovies[i].FilmTechnology + SelectedMovies[i].Date + SelectedMovies[i].Screen).ToString(), (SelectedMovies[i].newBlocks));
@@ -940,15 +987,6 @@ namespace CinemaSystemProjectB
 		private void MovieReservation_MouseEnter(object sender, EventArgs e)
 		{
 			checkAllBoxes();
-
-			if (page == 3)
-			{
-				ReservationPrice.Text = "0";
-				foreach (CustomerReservation movie in CustomerReservationPage.Controls)
-				{
-					ReservationPrice.Text = (Convert.ToDecimal(ReservationPrice.Text) + Convert.ToDecimal(movie.TotalPrice.Text.Replace("€", ""))).ToString();
-				}
-			}
 		}
 	}
 }

--- a/CinemaSystemProjectB/SeatReservation.cs
+++ b/CinemaSystemProjectB/SeatReservation.cs
@@ -285,31 +285,9 @@ namespace CinemaSystemProjectB
                     index++;
                 }
             }
-            if(clickedHere == true)
-            {
-                movie.TotalPrice.Text = (Convert.ToDecimal(movie.TotalPrice.Text.Replace("€", "")) - Convert.ToDecimal(movie.TotalGoodSeatPrice.Text.Replace("€", "")) -
-                                                                                    Convert.ToDecimal(movie.TotalBestSeatPrice.Text.Replace("€", ""))).ToString();
-                movie.NormalSeat.Text = NormalSeats.ToString();
-                movie.GoodSeat.Text = GoodSeats.ToString();
-                movie.BestSeat.Text = BestSeats.ToString();
-
-                string temp3 = ((GoodSeats * 1) < 10 ? "    " : (GoodSeats * 1) < 100 ? "  " : "") + (GoodSeats * 1).ToString();
-
-                string temp4 = ((BestSeats * 2) < 10 ? "    " : (BestSeats * 2) < 100 ? "  " : "") + (BestSeats * 2).ToString();
-
-                movie.TotalGoodSeatPrice.Text = "€" + temp3 + ",00";
-                movie.TotalBestSeatPrice.Text = "€" + temp4 + ",00";
-
-                movie.TotalPrice.Text = "€" + (Convert.ToDecimal(GoodSeats * 1) + Convert.ToDecimal(BestSeats * 2) + Convert.ToDecimal(movie.TotalPrice.Text.Replace("€", ""))).ToString();
-                //ReservationPrice
-                movie.Refresh();
-            }
 
             this.Close();
         }
-
-        bool clickedHere = CustomerReservation.clicked;
-        CustomerReservation movie = CustomerReservation.CustomerMovie;
 
         private void SeatReservation_Load(object sender, EventArgs e)
         {


### PR DESCRIPTION
- Optie om stoel te wijzigen bij filmoverzicht is verwijderd wegens vele conflicten met de prijzen en vertraging van de prestaties.
- Label toegevoegd met alle geselecteerde stoelen die de optie stoel wijzigen in filmoverzicht vervangt.
-Euro teken uit totale prijs label gehaald, zodat het niet meer dubbel verschijnt.